### PR TITLE
Added totals for State and RoUS for each state in Commodities Report

### DIFF
--- a/footprint/commodities.html
+++ b/footprint/commodities.html
@@ -108,7 +108,8 @@ async function main() {
     console.error("Error in main():", error);
   }
 }
-main();
+
+documentReady(main);
 
 var table
 function displayTable(locale, formatType) {

--- a/footprint/commodities.html
+++ b/footprint/commodities.html
@@ -35,41 +35,78 @@ function documentReady(callback) {
 
 let tableData = [];
 async function main() {
-  // compute the table data
-  const q = await model.matrix('q'); // Commodity
-  const sectors = await model.sectors();
-  documentReady(function() {
-    const notesDiv = document.getElementById("notes");
-    if (notesDiv) {
-        notesDiv.innerHTML = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>"
-        // + JSON.stringify(sectors, null, 2);
+  try {
+    // compute the table data
+    const q = await model.matrix('q'); // Commodity
+    const sectors = await model.sectors();
+    documentReady(function() {
+      const notesDiv = document.getElementById("notes");
+      if (notesDiv) {
+        notesDiv.innerHTML = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>";
+      }
+    });
+    const indicator = (await model.indicators()).filter(i => i.code === 'JOBS')[0];
+    const impacts = await model.matrix('D'); // Indicator_Sector (like industries)
+    
+    tableData = sectors.map(sector => {
+      const output = q.get(sector.index, 0);
+      const jobs = output * impacts.get(indicator.index, sector.index);
+      return {
+        ...sector,
+        output: Math.round(output),
+        jobs: Math.round(jobs)
+      };
+    });
+    
+    console.log("the table data is：", tableData);
+    tableData.forEach(item => { // For each object in array
+      item.jobsEasy = formatCell(item.jobs);
+      item.outputEasy = "$" + formatCell(item.output);
+    });
+    
+    // Using Tabulator column calculations to compute totals:
+    let hash = getHash();
+    if (hash.state) {
+      // Filter tableData into two parts:
+      let stateData = tableData.filter(row => row.location.includes(hash.state));
+      let rousData = tableData.filter(row => !row.location.includes(hash.state));
+      
+      // Create temporary Tabulator instances (in-memory only)
+      let stateCalcTable = new Tabulator(document.createElement("div"), {
+        data: stateData,
+        columns: [
+          {field:"output", bottomCalc:"sum"},
+          {field:"jobs", bottomCalc:"sum"},
+        ],
+      });
+      let rousCalcTable = new Tabulator(document.createElement("div"), {
+        data: rousData,
+        columns: [
+          {field:"output", bottomCalc:"sum"},
+          {field:"jobs", bottomCalc:"sum"},
+        ],
+      });
+      
+      // Retrieve the calculated sums
+      let stateOutput = stateCalcTable.getCalcResults("output");
+      let stateJobs = stateCalcTable.getCalcResults("jobs");
+      let rousOutput = rousCalcTable.getCalcResults("output");
+      let rousJobs = rousCalcTable.getCalcResults("jobs");
+      
+      // Update the summary section above the table
+      document.getElementById('state-name').textContent = `${hash.state} Total`;
+      document.getElementById('state-output').textContent = "$" + formatCell(stateOutput);
+      document.getElementById('state-jobs').textContent = formatCell(stateJobs);
+      document.getElementById('rous-output').textContent = "$" + formatCell(rousOutput);
+      document.getElementById('rous-jobs').textContent = formatCell(rousJobs);
     }
-  });
-  const indicator = (await model.indicators())
-    .filter(i => i.code === 'JOBS')[0];
-  const impacts = await model.matrix('D'); // Indicator_Sector (like industries)
-
-  tableData = sectors.map(sector => {
-    const output = q.get(sector.index, 0);
-    const jobs = output * impacts.get(indicator.index, sector.index);
-    return {
-      ...sector,
-      output: Math.round(output),
-      jobs: Math.round(jobs)
-    };
-  });
-  
-  console.log("the table data is：", tableData);
-  tableData.forEach(item => { // For each object in array
-    item.jobsEasy = formatCell(item.jobs);
-    item.outputEasy = "$" + formatCell(item.output);
-    // item.jobScientific = formatCell(item.jobs,'scientific');
-    // item.outputScientific = formatCell(item.output,'scientific');
-  }); 
-
-
-  // Initial table update with user's locale
-  displayTable(navigator.language, "simple");
+    
+    // Now initialize the main table with the tableData
+    displayTable(navigator.language, "simple");
+    
+  } catch(error) {
+    console.error("Error in main():", error);
+  }
 }
 main();
 
@@ -195,6 +232,19 @@ function updateTable(locale) {
 
 </script>
 
+<style>
+  .summary-card {
+    padding: 15px;
+    background: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    min-width: 200px;
+  }
+  .summary-card h4 {
+    margin: 0 0 10px 0;
+  }
+</style>
+
 </head>
 
 <body>
@@ -207,6 +257,21 @@ function updateTable(locale) {
     <a id="footprintLink" href="./" >State Impact Reports</a>
   </div>
   <div id="relocatedStateMenu"></div>
+
+  <div id="summary-section" style="margin:20px 0">
+    <div style="display:flex; gap:20px; max-width:800px">
+      <div class="summary-card">
+        <h4 id="state-name">State Total</h4>
+        <div>Output: <span id="state-output">-</span></div>
+        <div>Jobs: <span id="state-jobs">-</span></div>
+      </div>
+      <div class="summary-card">
+        <h4>Rest of US</h4>
+        <div>Output: <span id="rous-output">-</span></div>
+        <div>Jobs: <span id="rous-jobs">-</span></div>
+      </div>
+    </div>
+  </div>
 
   <div id="table" style="clear:both"></div>
 

--- a/footprint/commodities.html
+++ b/footprint/commodities.html
@@ -24,27 +24,26 @@ function hashChangedUseeio() {
 }
 
 function documentReady(callback) {
-    if (document.readyState === "loading") {
-        // The document is still loading, wait for it to finish
-        document.addEventListener("DOMContentLoaded", callback);
-    } else {
-        // The DOM is already fully loaded
-        callback();
-    }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", callback);
+  } else {
+    callback();
+  }
 }
 
 let tableData = [];
 async function main() {
   try {
-    // compute the table data
+    // Compute the table data
     const q = await model.matrix('q'); // Commodity
     const sectors = await model.sectors();
-    documentReady(function() {
-      const notesDiv = document.getElementById("notes");
-      if (notesDiv) {
-        notesDiv.innerHTML = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>";
-      }
-    });
+    
+    // Update notes (if any)
+    const notesDiv = document.getElementById("notes");
+    if (notesDiv) {
+      notesDiv.innerHTML = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>";
+    }
+    
     const indicator = (await model.indicators()).filter(i => i.code === 'JOBS')[0];
     const impacts = await model.matrix('D'); // Indicator_Sector (like industries)
     
@@ -58,53 +57,53 @@ async function main() {
       };
     });
     
-    console.log("the table data is：", tableData);
-    tableData.forEach(item => { // For each object in array
+    console.log("The table data is:", tableData);
+    tableData.forEach(item => {
       item.jobsEasy = formatCell(item.jobs);
       item.outputEasy = "$" + formatCell(item.output);
     });
     
-    // Using Tabulator column calculations to compute totals:
+    // Use Tabulator column calculations to compute totals
     let hash = getHash();
     if (hash.state) {
       // Filter tableData into two parts:
       let stateData = tableData.filter(row => row.location.includes(hash.state));
       let rousData = tableData.filter(row => !row.location.includes(hash.state));
       
-      // Create temporary Tabulator instances (in-memory only)
+      // Create temporary Tabulator instances (in-memory only) to compute sums
       let stateCalcTable = new Tabulator(document.createElement("div"), {
         data: stateData,
         columns: [
-          {field:"output", bottomCalc:"sum"},
-          {field:"jobs", bottomCalc:"sum"},
+          { field: "output", bottomCalc: "sum" },
+          { field: "jobs", bottomCalc: "sum" },
         ],
       });
       let rousCalcTable = new Tabulator(document.createElement("div"), {
         data: rousData,
         columns: [
-          {field:"output", bottomCalc:"sum"},
-          {field:"jobs", bottomCalc:"sum"},
+          { field: "output", bottomCalc: "sum" },
+          { field: "jobs", bottomCalc: "sum" },
         ],
       });
       
-      // Retrieve the calculated sums
       let stateOutput = stateCalcTable.getCalcResults("output");
       let stateJobs = stateCalcTable.getCalcResults("jobs");
       let rousOutput = rousCalcTable.getCalcResults("output");
       let rousJobs = rousCalcTable.getCalcResults("jobs");
       
-      // Update the summary section above the table
-      document.getElementById('state-name').textContent = `${hash.state} Total`;
-      document.getElementById('state-output').textContent = "$" + formatCell(stateOutput);
-      document.getElementById('state-jobs').textContent = formatCell(stateJobs);
-      document.getElementById('rous-output').textContent = "$" + formatCell(rousOutput);
-      document.getElementById('rous-jobs').textContent = formatCell(rousJobs);
+      // Write two lines of summary text in the totals container:
+      let totalsDiv = document.getElementById("totals");
+      if (totalsDiv) {
+        totalsDiv.innerHTML = 
+          `State Total: $${formatCell(stateOutput)} , with ${formatCell(stateJobs)} jobs.<br>` +
+          `Rest of US: $${formatCell(rousOutput)} , with ${formatCell(rousJobs)} jobs.`;
+      }
     }
     
     // Now initialize the main table with the tableData
     displayTable(navigator.language, "simple");
     
-  } catch(error) {
+  } catch (error) {
     console.error("Error in main():", error);
   }
 }
@@ -261,18 +260,10 @@ function updateTable(locale) {
 
   <div id="summary-section" style="margin:20px 0">
     <div style="display:flex; gap:20px; max-width:800px">
-      <div class="summary-card">
-        <h4 id="state-name">State Total</h4>
-        <div>Output: <span id="state-output">-</span></div>
-        <div>Jobs: <span id="state-jobs">-</span></div>
-      </div>
-      <div class="summary-card">
-        <h4>Rest of US</h4>
-        <div>Output: <span id="rous-output">-</span></div>
-        <div>Jobs: <span id="rous-jobs">-</span></div>
-      </div>
     </div>
   </div>
+
+  <div id="totals" style="margin:20px 0; font-size:1.1em;"></div>
 
   <div id="table" style="clear:both"></div>
 

--- a/footprint/commodities.html
+++ b/footprint/commodities.html
@@ -34,18 +34,20 @@ function documentReady(callback) {
 let tableData = [];
 async function main() {
   try {
+    console.log("Starting main() via window.onload");
+    
     // Compute the table data
     const q = await model.matrix('q'); // Commodity
     const sectors = await model.sectors();
     
-    // Update notes (if any)
+    // Update the notes div if present
     const notesDiv = document.getElementById("notes");
     if (notesDiv) {
       notesDiv.innerHTML = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>";
     }
     
     const indicator = (await model.indicators()).filter(i => i.code === 'JOBS')[0];
-    const impacts = await model.matrix('D'); // Indicator_Sector (like industries)
+    const impacts = await model.matrix('D'); // Indicator_Sector
     
     tableData = sectors.map(sector => {
       const output = q.get(sector.index, 0);
@@ -57,46 +59,39 @@ async function main() {
       };
     });
     
-    console.log("The table data is:", tableData);
+    console.log("Table data loaded, length:", tableData.length);
     tableData.forEach(item => {
       item.jobsEasy = formatCell(item.jobs);
       item.outputEasy = "$" + formatCell(item.output);
     });
     
-    // Use Tabulator column calculations to compute totals
+    // Compute totals only if a state is specified in the URL hash:
     let hash = getHash();
     if (hash.state) {
-      // Filter tableData into two parts:
       let stateData = tableData.filter(row => row.location.includes(hash.state));
       let rousData = tableData.filter(row => !row.location.includes(hash.state));
       
-      // Create temporary Tabulator instances (in-memory only) to compute sums
-      let stateCalcTable = new Tabulator(document.createElement("div"), {
-        data: stateData,
-        columns: [
-          { field: "output", bottomCalc: "sum" },
-          { field: "jobs", bottomCalc: "sum" },
-        ],
-      });
-      let rousCalcTable = new Tabulator(document.createElement("div"), {
-        data: rousData,
-        columns: [
-          { field: "output", bottomCalc: "sum" },
-          { field: "jobs", bottomCalc: "sum" },
-        ],
-      });
+      console.log("State rows:", stateData.length, "RoUS rows:", rousData.length);
       
-      let stateOutput = stateCalcTable.getCalcResults("output");
-      let stateJobs = stateCalcTable.getCalcResults("jobs");
-      let rousOutput = rousCalcTable.getCalcResults("output");
-      let rousJobs = rousCalcTable.getCalcResults("jobs");
-      
-      // Write two lines of summary text in the totals container:
+      const stateTotals = stateData.reduce((acc, row) => {
+        acc.output += row.output || 0;
+        acc.jobs += row.jobs || 0;
+        return acc;
+      }, { output: 0, jobs: 0 });
+
+      const rousTotals = rousData.reduce((acc, row) => {
+        acc.output += row.output || 0;
+        acc.jobs += row.jobs || 0;
+        return acc;
+      }, { output: 0, jobs: 0 });
+
+      console.log("Calculated totals:", { stateTotals, rousTotals });
+
       let totalsDiv = document.getElementById("totals");
       if (totalsDiv) {
         totalsDiv.innerHTML = 
-          `State Total: $${formatCell(stateOutput)} , with ${formatCell(stateJobs)} jobs.<br>` +
-          `Rest of US: $${formatCell(rousOutput)} , with ${formatCell(rousJobs)} jobs.`;
+          `<strong>State Total:</strong> $${formatCell(stateTotals.output)}, with ${formatCell(stateTotals.jobs)} jobs.<br>` +
+          `<strong>Rest of US:</strong> $${formatCell(rousTotals.output)}, with ${formatCell(rousTotals.jobs)} jobs.`;
       }
     }
     
@@ -104,11 +99,13 @@ async function main() {
     displayTable(navigator.language, "simple");
     
   } catch (error) {
-    console.error("Error in main():", error);
+    console.error("Error in main():", error.stack);
   }
 }
 
-documentReady(main);
+window.onload = function() {
+  main();
+};
 
 var table
 function displayTable(locale, formatType) {


### PR DESCRIPTION
The commodities report now shows the total output and jobs for the state, as well as the Rest of the US, when a state is parsed in the hash. When no state is selected in the report, the totals do not show. 