### PR TITLE
UI changes + US Totals calculated for no hash params

### DIFF
--- a/footprint/commodities.html
+++ b/footprint/commodities.html
@@ -43,21 +43,18 @@ async function main() {
     // Update the notes div if present
     const notesDiv = document.getElementById("notes");
     if (notesDiv) {
-
-      let hash = getHash();
+      let hash = getHash();  
       let notesContent = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>";
-
-    // only add RoUS note if a state is selected
+      
+      // Only add the RoUS explanation if a state is selected
       if (hash.state) {
-        notes.innerHTML += 
-        '<div style="margin-top:20px; font-style:italic; color:#666;">' +
-        'Note: The "Rest of US" total varies by state because it represents the total minus the selected state\'s value. ' +
-        'States with larger economic output will show smaller Rest of US totals, as they account for a larger portion of the national total.' +
-        '</div>';
+        notesContent += '<div style="margin-top:20px; font-style:italic; color:#666;">' +
+          'Note: The "Rest of US" total varies by state because it represents the total minus the selected state\'s value. ' +
+          'States with larger economic output will show smaller Rest of US totals, as they account for a larger portion of the national total.' +
+          '</div>';
       }
-    
-    notesDiv.innerHTML = notesContent;
-
+      
+      notesDiv.innerHTML = notesContent;
     }
     
     const indicator = (await model.indicators()).filter(i => i.code === 'JOBS')[0];

--- a/footprint/commodities.html
+++ b/footprint/commodities.html
@@ -44,6 +44,10 @@ async function main() {
     const notesDiv = document.getElementById("notes");
     if (notesDiv) {
       notesDiv.innerHTML = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>";
+      '<div style="margin-top:20px; font-style:italic; color:#666;">' +
+      'Note: The "Rest of US" total varies by state because it represents the total minus the selected state\'s value. ' +
+      'States with larger economic output will show smaller Rest of US totals, as they account for a larger portion of the national total.' +
+      '</div>';
     }
     
     const indicator = (await model.indicators()).filter(i => i.code === 'JOBS')[0];
@@ -273,7 +277,12 @@ function updateTable(locale) {
 
   <div id="table" style="clear:both"></div>
 
-  <div id="notes" style="clear:both"></div>
+  <div id="notes" style="clear:both">
+    <div style="margin-top:20px; font-style:italic; color:#666;">
+      Note: The "Rest of US" total varies by state because it represents the total minus the selected state's value. 
+      States with larger economic output will show smaller Rest of US totals, as they account for a larger portion of the national total.
+    </div>
+  </div>
 
 </div>
 

--- a/footprint/commodities.html
+++ b/footprint/commodities.html
@@ -43,17 +43,21 @@ async function main() {
     // Update the notes div if present
     const notesDiv = document.getElementById("notes");
     if (notesDiv) {
+
+      let hash = getHash();
+      let notesContent = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>";
+
+    // only add RoUS note if a state is selected
       if (hash.state) {
-        notesDiv.innerHTML = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>" +
+        notes.innerHTML += 
         '<div style="margin-top:20px; font-style:italic; color:#666;">' +
         'Note: The "Rest of US" total varies by state because it represents the total minus the selected state\'s value. ' +
         'States with larger economic output will show smaller Rest of US totals, as they account for a larger portion of the national total.' +
         '</div>';
       }
-      else {
-        // no data source shown when no state selected
-        notesDiv.innerHTML = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>";
-      }
+    
+    notesDiv.innerHTML = notesContent;
+
     }
     
     const indicator = (await model.indicators()).filter(i => i.code === 'JOBS')[0];
@@ -284,10 +288,10 @@ function updateTable(locale) {
   <div id="table" style="clear:both"></div>
 
   <div id="notes" style="clear:both">
-    <div style="margin-top:20px; font-style:italic; color:#666;">
+    <!-- <div style="margin-top:20px; font-style:italic; color:#666;">
       Note: The "Rest of US" total varies by state because it represents the total minus the selected state's value. 
       States with larger economic output will show smaller Rest of US totals, as they account for a larger portion of the national total.
-    </div>
+    </div> -->
   </div>
 
 </div>

--- a/footprint/commodities.html
+++ b/footprint/commodities.html
@@ -43,7 +43,7 @@ async function main() {
     // Update the notes div if present
     const notesDiv = document.getElementById("notes");
     if (notesDiv) {
-      notesDiv.innerHTML = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>";
+      notesDiv.innerHTML = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>" +
       '<div style="margin-top:20px; font-style:italic; color:#666;">' +
       'Note: The "Rest of US" total varies by state because it represents the total minus the selected state\'s value. ' +
       'States with larger economic output will show smaller Rest of US totals, as they account for a larger portion of the national total.' +

--- a/footprint/commodities.html
+++ b/footprint/commodities.html
@@ -43,19 +43,19 @@ async function main() {
     const notesDiv = document.getElementById("notes");
     if (notesDiv) {
       let hash = getHash();
-      console.log("Current hash state:", hash); 
-  
-      let notesContent = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>";
-  
-      if (hash && hash.state) { 
-        console.log("State found in hash:", hash.state); 
+      let notesContent = "";
+
+      notesContent = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>";
+
+      // Only add RoUS note if state parameter exists
+      if (hash && hash.state) {
         notesContent += '<div style="margin-top:20px; font-style:italic; color:#666;">' +
           'Note: The "Rest of US" total varies by state because it represents the total minus the selected state\'s value. ' +
           'States with larger economic output will show smaller Rest of US totals, as they account for a larger portion of the national total.' +
           '</div>';
       }
-  
-    notesDiv.innerHTML = notesContent;
+
+      notesDiv.innerHTML = notesContent;
     }
     
     const indicator = (await model.indicators()).filter(i => i.code === 'JOBS')[0];

--- a/footprint/commodities.html
+++ b/footprint/commodities.html
@@ -40,21 +40,22 @@ async function main() {
     const q = await model.matrix('q'); // Commodity
     const sectors = await model.sectors();
     
-    // Update the notes div if present
     const notesDiv = document.getElementById("notes");
     if (notesDiv) {
-      let hash = getHash();  
+      let hash = getHash();
+      console.log("Current hash state:", hash); 
+  
       let notesContent = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>";
-      
-      // Only add the RoUS explanation if a state is selected
-      if (hash.state) {
+  
+      if (hash && hash.state) { 
+        console.log("State found in hash:", hash.state); 
         notesContent += '<div style="margin-top:20px; font-style:italic; color:#666;">' +
           'Note: The "Rest of US" total varies by state because it represents the total minus the selected state\'s value. ' +
           'States with larger economic output will show smaller Rest of US totals, as they account for a larger portion of the national total.' +
           '</div>';
       }
-      
-      notesDiv.innerHTML = notesContent;
+  
+    notesDiv.innerHTML = notesContent;
     }
     
     const indicator = (await model.indicators()).filter(i => i.code === 'JOBS')[0];
@@ -284,11 +285,7 @@ function updateTable(locale) {
 
   <div id="table" style="clear:both"></div>
 
-  <div id="notes" style="clear:both">
-    <!-- <div style="margin-top:20px; font-style:italic; color:#666;">
-      Note: The "Rest of US" total varies by state because it represents the total minus the selected state's value. 
-      States with larger economic output will show smaller Rest of US totals, as they account for a larger portion of the national total.
-    </div> -->
+  <div id="notes" style="clear:both; margin-top:20px;">
   </div>
 
 </div>

--- a/footprint/commodities.html
+++ b/footprint/commodities.html
@@ -43,11 +43,17 @@ async function main() {
     // Update the notes div if present
     const notesDiv = document.getElementById("notes");
     if (notesDiv) {
-      notesDiv.innerHTML = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>" +
-      '<div style="margin-top:20px; font-style:italic; color:#666;">' +
-      'Note: The "Rest of US" total varies by state because it represents the total minus the selected state\'s value. ' +
-      'States with larger economic output will show smaller Rest of US totals, as they account for a larger portion of the national total.' +
-      '</div>';
+      if (hash.state) {
+        notesDiv.innerHTML = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>" +
+        '<div style="margin-top:20px; font-style:italic; color:#666;">' +
+        'Note: The "Rest of US" total varies by state because it represents the total minus the selected state\'s value. ' +
+        'States with larger economic output will show smaller Rest of US totals, as they account for a larger portion of the national total.' +
+        '</div>';
+      }
+      else {
+        // no data source shown when no state selected
+        notesDiv.innerHTML = "<br>From useeio-json/models/2020/" + getModelFolderName() + "/sectors.json<br>";
+      }
     }
     
     const indicator = (await model.indicators()).filter(i => i.code === 'JOBS')[0];

--- a/footprint/commodities.html
+++ b/footprint/commodities.html
@@ -67,6 +67,7 @@ async function main() {
     
     // Compute totals only if a state is specified in the URL hash:
     let hash = getHash();
+    let totalsDiv = document.getElementById("totals");
     if (hash.state) {
       let stateData = tableData.filter(row => row.location.includes(hash.state));
       let rousData = tableData.filter(row => !row.location.includes(hash.state));
@@ -87,11 +88,24 @@ async function main() {
 
       console.log("Calculated totals:", { stateTotals, rousTotals });
 
-      let totalsDiv = document.getElementById("totals");
       if (totalsDiv) {
         totalsDiv.innerHTML = 
           `<strong>State Total:</strong> $${formatCell(stateTotals.output)}, with ${formatCell(stateTotals.jobs)} jobs.<br>` +
           `<strong>Rest of US:</strong> $${formatCell(rousTotals.output)}, with ${formatCell(rousTotals.jobs)} jobs.`;
+      }
+    } else {
+      // Calculate US total when no state is selected
+      const usTotals = tableData.reduce((acc, row) => {
+        acc.output += row.output || 0;
+        acc.jobs += row.jobs || 0;
+        return acc;
+      }, { output: 0, jobs: 0 });
+
+      console.log("Calculated US totals:", usTotals);
+
+      if (totalsDiv) {
+        totalsDiv.innerHTML = 
+          `<strong>US Total:</strong> $${formatCell(usTotals.output)}, with ${formatCell(usTotals.jobs)} jobs.`;
       }
     }
     
@@ -254,11 +268,6 @@ function updateTable(locale) {
     <a id="footprintLink" href="./" >State Impact Reports</a>
   </div>
   <div id="relocatedStateMenu"></div>
-
-  <div id="summary-section" style="margin:20px 0">
-    <div style="display:flex; gap:20px; max-width:800px">
-    </div>
-  </div>
 
   <div id="totals" style="margin:20px 0; font-size:1.1em;"></div>
 

--- a/footprint/commodities.html
+++ b/footprint/commodities.html
@@ -269,7 +269,7 @@ function updateTable(locale) {
   </div>
   <div id="relocatedStateMenu"></div>
 
-  <div id="totals" style="margin:20px 0; font-size:1.1em;"></div>
+  <div id="totals" style="margin:10px 0; font-size:1.1em;"></div>
 
   <div id="table" style="clear:both"></div>
 


### PR DESCRIPTION
Following changes made in the commodities report:

1. Removed the empty space between the state dropdown and the Totals line.
2. Added note explaining why each state's RoUS values differ (note only shows when there is a state parameter in the URL - when only commodities.html report is loaded, the note is hidden)
3. US Totals show instead of State/RoUS totals when no state parameter in URL. 

Please review here: https://lakshit-pant.github.io/useeio.js/footprint/commodities.html#state=CA