### PR TITLE
Added JSON structure in sector impacts report to support stretched chord

### DIFF
--- a/footprint/sector_supply_impacts.html
+++ b/footprint/sector_supply_impacts.html
@@ -49,6 +49,7 @@
     </div>
     <div id="table"></div>
     <a href="#" id="showAllLink" style="display:block; margin: 10px 0 20px 0;">Show all rows</a>
+    <!-- <div id="chord-diagram" style="width: 800px; height: 800px; margin: 20px auto;"></div>  --> 
   </div>
   
   <script src="./config.js"></script>
@@ -58,6 +59,12 @@
     let table;
     let currentData = null; // Add this to track current data state
     let allResults = null; // Add this to store full dataset
+
+    // creating function chordData to store the data for the chord diagram
+    let chordData = {
+        nodes: [],
+        links: []
+    };
 
     document.addEventListener('hashChangeEvent', hashChangedUseeio, false);
     function hashChangedUseeio() {
@@ -240,6 +247,46 @@
           }
       }
 
+      // function to generate chord data
+      // This function creates the data structure for the chord diagram
+      function generateChordData(sectors, indicators, total, byIndicator) {
+          const nodes = [
+              // Add sectors as nodes, i.e. arrays of all elements
+              ...sectors.map(s => ({
+                  id: s.code,
+                  name: s.name,
+                  type: 'sector',
+                  group: 1
+              })),
+              // Add indicators as nodes
+              ...indicators.map(i => ({
+                  id: i.code,
+                  name: i.name || i.code,
+                  type: 'indicator',
+                  group: 2
+              }))
+          ];
+
+          const links = [];
+          sectors.forEach(sector => {
+              indicators.forEach(indicator => {
+                  const value = Math.abs(byIndicator[indicator.code][sector.index]);
+                  if (value > 0) {
+                      links.push({
+                          source: sector.code,
+                          target: indicator.code,
+                          value: value
+                      });
+                  }
+              });
+          });
+
+          return {
+              nodes: nodes,
+              links: links
+          };
+      }
+
       // Create initial table with sorted data
       function initializeTable(formatType) {
           const tableConfig = {
@@ -306,7 +353,6 @@
           return new Tabulator("#table", tableConfig);
       }
 
-      // Add this before table initialization
       let isShowingAllRows = false;
 
       // Initialize table with simple format by default
@@ -351,6 +397,12 @@
       showAllLink.style.display = 'block';
       currentData = sortedResults;
       isShowingAllRows = false;
+
+      // Updating the main() function to generate chord data
+      chordData = generateChordData(sectors, indicators, total, byIndicator);
+      
+      // Console logging structure for debugging
+      console.log('Chord data generated:', chordData);
 
     }
     main();


### PR DESCRIPTION
### Added JSON structure in one report, which includes:

**nodes: Array of all elements (sectors and indicators)**
1. id: Unique identifier (sector or indicator code)
2. name: Display name
3. type: Either 'sector' or 'indicator'
4. group: Grouping number for visualization (1=sectors, 2=indicators)

**links: Array of connections between sectors and indicators**

1. source: Sector code
2. target: Indicator code
3. value: Impact value

Hope is that the structure should automatically update with state change, support the stretched chord visualization, and maintain connections between our sectors and indicators.